### PR TITLE
feat: set logo image as site favicon

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,13 @@ import vuetify from 'vite-plugin-vuetify'
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
+  app: {
+    head: {
+      link: [
+        { rel: 'icon', type: 'image/jpeg', href: '/img/logo.jpg' }
+      ]
+    }
+  },
   css: [
     'vuetify/styles',
     '@mdi/font/css/materialdesignicons.min.css'


### PR DESCRIPTION
## Summary
- add global head link for `/img/logo.jpg` to serve as favicon

## Testing
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a788109ba0832f819fd296b2d376d4