### PR TITLE
feat: add detailed services section

### DIFF
--- a/components/PreciosTable.vue
+++ b/components/PreciosTable.vue
@@ -1,0 +1,34 @@
+<template>
+  <v-table density="comfortable" class="mb-4">
+    <thead>
+      <tr>
+        <th class="text-left">Técnica / Tamaño</th>
+        <th class="text-left">3-10 personas</th>
+        <th class="text-left">11-20 personas</th>
+        <th class="text-left">21+ personas</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Acrílico 30x40 cm</td>
+        <td>₡14&nbsp;000</td>
+        <td>₡13&nbsp;000</td>
+        <td>₡12&nbsp;000</td>
+      </tr>
+      <tr>
+        <td>Acrílico 20x20 cm</td>
+        <td>₡11&nbsp;500</td>
+        <td>₡10&nbsp;500</td>
+        <td>₡9&nbsp;500</td>
+      </tr>
+      <tr>
+        <td>Acuarela</td>
+        <td>₡12&nbsp;500</td>
+        <td>₡11&nbsp;000</td>
+        <td>₡9&nbsp;500</td>
+      </tr>
+    </tbody>
+  </v-table>
+</template>
+
+<script setup lang="ts"></script>

--- a/components/ProcesoPasoAPaso.vue
+++ b/components/ProcesoPasoAPaso.vue
@@ -1,5 +1,0 @@
-<template>
-  <v-container>
-    <p>ProcesoPasoAPaso placeholder</p>
-  </v-container>
-</template>

--- a/components/ServicioCard.vue
+++ b/components/ServicioCard.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-card class="mb-8">
+    <v-card-title class="text-h6">{{ title }}</v-card-title>
+    <v-card-text>
+      <p class="mb-4">{{ description }}</p>
+      <ul v-if="features && features.length" class="mb-4 pl-4">
+        <li v-for="(f, i) in features" :key="i">{{ f }}</li>
+      </ul>
+      <div v-if="techniques && techniques.length" class="mb-4">
+        <strong>Técnicas:</strong>
+        <v-chip-group class="mt-2" column>
+          <v-chip
+            v-for="(t, i) in techniques"
+            :key="i"
+            class="ma-1"
+            color="primary"
+            variant="tonal"
+            size="small"
+          >
+            {{ t }}
+          </v-chip>
+        </v-chip-group>
+      </div>
+      <p v-if="priceInfo" class="mb-4"><strong>{{ priceInfo }}</strong></p>
+      <slot />
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+const props = defineProps({
+  title: { type: String, required: true },
+  description: { type: String, required: true },
+  features: { type: Array as () => string[], default: () => [] },
+  techniques: { type: Array as () => string[], default: () => [] },
+  priceInfo: { type: String, default: '' },
+})
+</script>

--- a/components/ServicioItem.vue
+++ b/components/ServicioItem.vue
@@ -1,5 +1,0 @@
-<template>
-  <v-container>
-    <p>ServicioItem placeholder</p>
-  </v-container>
-</template>

--- a/components/ServiciosSection.vue
+++ b/components/ServiciosSection.vue
@@ -1,0 +1,39 @@
+<template>
+  <v-container class="py-12">
+    <h1 class="text-h4 text-center mb-8">Servicios</h1>
+    <v-row>
+      <v-col cols="12" md="6">
+        <ServicioCard
+          title="Talleres compartidos"
+          description="Talleres grupales abiertos al público con fechas programadas."
+          :features="[
+            'Anunciados públicamente por redes sociales',
+            'Diversas temáticas y técnicas',
+            'Ubicados en GAM y occidente de Costa Rica'
+          ]"
+          :techniques="['Acuarela', 'Acrílico sobre lienzo']"
+          price-info="Rango de precios: ₡12 500 - ₡25 000"
+        />
+      </v-col>
+      <v-col cols="12" md="6">
+        <ServicioCard
+          title="Talleres privados"
+          description="Talleres privados que requieren cotización anticipada."
+          :features="[
+            'Tamaños de lienzo: 20x20cm y 30x40cm'
+          ]"
+          :techniques="['Acuarela', 'Acrílico sobre lienzo']"
+        >
+          <p class="mb-4">Mínimo 1 mes de anticipación.</p>
+          <PreciosTable />
+          <ul class="pl-4">
+            <li>Al precio final cotizado se debe sumar 2% de I.V.A.</li>
+            <li>Contrato formal debe ser firmado al momento antes de la reserva.</li>
+          </ul>
+        </ServicioCard>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts"></script>

--- a/pages/servicios.vue
+++ b/pages/servicios.vue
@@ -1,5 +1,6 @@
 <template>
-  <ServicioItem />
-  <ProcesoPasoAPaso />
+  <ServiciosSection />
   <ContactoCTA />
 </template>
+
+<script setup lang="ts"></script>


### PR DESCRIPTION
## Summary
- replace placeholder components with structured services section using Vuetify cards and responsive grid
- add pricing table for private workshops with IVA and contract notes
- update services page to include new section and WhatsApp contact CTA

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7db042f40832fa18fc797abbc77ee