### PR TITLE
feat: complete community section

### DIFF
--- a/components/BannerComunidad.vue
+++ b/components/BannerComunidad.vue
@@ -1,24 +1,56 @@
 <template>
-  <v-container class="py-12">
-    <v-row align="center">
-      <v-col cols="12" md="6">
+  <v-container class="py-8 py-md-12">
+    <v-row align="center" justify="center">
+      <!-- Imagen - Responsive -->
+      <v-col cols="12" md="6" class="text-center">
         <v-img
-          src="https://via.placeholder.com/600x400"
+          src="/img/logo.jpg"
           alt="Comunidad Soy Gioco"
-          height="300"
-          cover
+          :max-height="$vuetify.display.mobile ? 200 : 300"
+          :max-width="$vuetify.display.mobile ? 200 : 400"
+          contain
+          class="mx-auto rounded-lg"
         />
       </v-col>
-      <v-col cols="12" md="6">
-        <h1 class="text-h4 font-weight-bold mb-2">Comunidad Exclusiva Soy Gioco</h1>
-        <p class="mb-2">
+      
+      <!-- Contenido de texto -->
+      <v-col cols="12" md="6" class="text-center text-md-left">
+        <h1 class="text-h5 text-md-h4 font-weight-bold mb-3">
+          Comunidad Exclusiva Soy Gioco
+        </h1>
+        <p class="text-body-1 mb-3">
           Comunidad cerrada para participantes de talleres. Acceso gratuito y exclusivo para
           quienes han asistido al menos a un taller.
         </p>
-        <p class="text-subtitle-1">Más de 90 miembros activos</p>
+        <v-chip
+          color="primary"
+          size="small"
+          variant="outlined"
+          class="mb-2"
+        >
+          <v-icon start icon="mdi-account-group"></v-icon>
+          Más de 90 miembros activos
+        </v-chip>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+// No se necesita lógica adicional para este componente
+</script>
+
+<style scoped>
+/* Estilos adicionales para mejor responsive */
+@media (max-width: 960px) {
+  .v-container {
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+}
+
+/* Asegurar que la imagen no se desborde */
+.v-img {
+  border-radius: 8px;
+}
+</style>

--- a/components/BannerComunidad.vue
+++ b/components/BannerComunidad.vue
@@ -1,5 +1,24 @@
 <template>
-  <v-container>
-    <p>BannerComunidad placeholder</p>
+  <v-container class="py-12">
+    <v-row align="center">
+      <v-col cols="12" md="6">
+        <v-img
+          src="https://via.placeholder.com/600x400"
+          alt="Comunidad Soy Gioco"
+          height="300"
+          cover
+        />
+      </v-col>
+      <v-col cols="12" md="6">
+        <h1 class="text-h4 font-weight-bold mb-2">Comunidad Exclusiva Soy Gioco</h1>
+        <p class="mb-2">
+          Comunidad cerrada para participantes de talleres. Acceso gratuito y exclusivo para
+          quienes han asistido al menos a un taller.
+        </p>
+        <p class="text-subtitle-1">Más de 90 miembros activos</p>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
+
+<script setup lang="ts"></script>

--- a/components/BotonRegistro.vue
+++ b/components/BotonRegistro.vue
@@ -1,5 +1,18 @@
 <template>
-  <v-container>
-    <p>BotonRegistro placeholder</p>
+  <v-container class="py-12 text-center">
+    <h2 class="text-h5 font-weight-medium mb-4">
+      ¿Quieres ser parte de esta comunidad exclusiva?
+    </h2>
+    <p class="mb-6">
+      Participa en cualquiera de nuestros talleres y obtén acceso a nuestra comunidad cerrada.
+    </p>
+    <v-btn color="primary" to="/talleres" class="mb-4">
+      Ver Talleres Disponibles
+    </v-btn>
+    <p class="text-body-2">
+      Después de asistir a un taller, serás invitado vía WhatsApp al +506 7076 3760
+    </p>
   </v-container>
 </template>
+
+<script setup lang="ts"></script>

--- a/components/ListaBeneficios.vue
+++ b/components/ListaBeneficios.vue
@@ -1,5 +1,58 @@
 <template>
-  <v-container>
-    <p>ListaBeneficios placeholder</p>
+  <v-container class="py-12">
+    <h2 class="text-h5 text-center mb-8">Beneficios Exclusivos</h2>
+    <v-row>
+      <v-col
+        v-for="benefit in benefits"
+        :key="benefit.title"
+        cols="12"
+        sm="6"
+        lg="4"
+        class="d-flex"
+      >
+        <v-card class="pa-4 text-center flex-grow-1">
+          <v-icon :icon="benefit.icon" size="36" color="primary" />
+          <h3 class="text-h6 font-weight-medium mt-3 mb-2">{{ benefit.title }}</h3>
+          <p class="text-body-2">{{ benefit.description }}</p>
+        </v-card>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
+
+<script setup lang="ts">
+interface Benefit {
+  title: string
+  description: string
+  icon: string
+}
+
+const benefits: Benefit[] = [
+  {
+    title: 'Descuentos Especiales',
+    description: 'Acceso a descuentos exclusivos en talleres y productos',
+    icon: 'mdi-percent',
+  },
+  {
+    title: 'Acceso Anticipado',
+    description: 'Inscríbete a talleres 1 día antes que el público general',
+    icon: 'mdi-clock-fast',
+  },
+  {
+    title: 'Actividades Exclusivas',
+    description:
+      'Desayunos con pintura, tours de arte, visitas a museos y eventos especiales',
+    icon: 'mdi-account-group',
+  },
+  {
+    title: 'Talleres Virtuales Gratuitos',
+    description: 'Sesiones en línea exclusivas cada tres meses',
+    icon: 'mdi-video',
+  },
+  {
+    title: 'Noticias de Arte Nacional',
+    description: 'Mantente al día con el mundo artístico costarricense',
+    icon: 'mdi-newspaper',
+  },
+]
+</script>

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -3,7 +3,7 @@
     <v-app-bar-nav-icon class="d-sm-none" @click="drawer = !drawer" />
     <v-toolbar-title>
           <NuxtLink to="/">
-        <img src="/public/img/logo.jpg" alt="SoyGioco Logo" style="height: 40px;" />
+        <v-img src="/img/logo.jpg" alt="SoyGioco Logo" style="height: 40px;" />
       </NuxtLink>
     </v-toolbar-title>
     <v-spacer />


### PR DESCRIPTION
## Summary
- Implement banner for community page with responsive placeholder image and membership details
- Add benefits list showcasing exclusive perks with icons
- Provide call-to-action button directing to workshops and explaining access via WhatsApp after participation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a80088a838832f91e9586d2c65c9ad