### PR TITLE
docs: refresh AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # Overview and Purpose
-SoyGioco.art is a Nuxt 4.0.3 application that showcases artwork, services and community content using Vue 3 and Vuetify for a responsive UI.
+SoyGioco.art is a Nuxt 4.0.3 application that showcases artwork, services, community content, and blog articles using Vue 3 and Vuetify for a responsive UI.
 
 # Technical Specifications
 - **Framework**: Nuxt 4.0.3 with Vue 3 Composition API
 - **UI Library**: Vuetify 3.6.0 with MDI icons
 - **Modules**: `@nuxtjs/sitemap` for SEO and `@nuxtjs/strapi` for upcoming CMS integration
+- **Libraries**: `marked` for rendering blog content
 - **Configuration**: `nuxt.config.ts` defines site metadata, custom sitemap routes and the Vite Vuetify plugin
 - **Plugins**: `plugins/vuetify.ts` registers a custom `soygioco` theme
 
@@ -31,4 +32,6 @@ export default defineNuxtConfig({
 - [layouts/AGENTS.md](layouts/AGENTS.md)
 - [plugins/AGENTS.md](plugins/AGENTS.md)
 - [public/AGENTS.md](public/AGENTS.md)
+- [composables/AGENTS.md](composables/AGENTS.md)
+- [data/AGENTS.md](data/AGENTS.md)
 

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -1,10 +1,11 @@
 # Overview and Purpose
-Reusable Vue components that assemble the application's UI, from navigation to galleries and contact forms.
+Reusable Vue components that assemble the application's UI, from navigation to galleries, blog interfaces, and contact forms.
 
 # Technical Specifications
 - Built with Vue 3 `<script setup lang="ts">`
 - Styled using Vuetify 3.6.0 components and utility classes
 - Auto-registered by Nuxt 4 when placed in this directory
+- Blog components under `components/blog/` render Strapi content and markdown
 
 # Usage Examples
 ```vue
@@ -27,4 +28,5 @@ Reusable Vue components that assemble the application's UI, from navigation to g
 - [../pages/AGENTS.md](../pages/AGENTS.md)
 - [../layouts/AGENTS.md](../layouts/AGENTS.md)
 - [../plugins/AGENTS.md](../plugins/AGENTS.md)
+- [../composables/AGENTS.md](../composables/AGENTS.md)
 

--- a/composables/AGENTS.md
+++ b/composables/AGENTS.md
@@ -1,0 +1,32 @@
+# Overview and Purpose
+Reusable logic and state management functions built with the Vue 3 Composition API. They coordinate data fetching, SEO metadata, and cross-component state.
+
+# Technical Specifications
+- Implemented as TypeScript modules returning functions that can be used in components and pages
+- `useStrapiApi` wraps `@nuxtjs/strapi` to fetch CMS content with caching
+- `useBlog` exposes helpers for retrieving blog posts and articles
+- Other helpers like `useSeo` manage meta tags for SEO
+
+# Usage Examples
+```ts
+<script setup lang="ts">
+const { all, fetchBlogPosts } = useBlog()
+await fetchBlogPosts()
+</script>
+```
+
+# Best Practices
+- Prefix files with `use` and keep them focused on a single responsibility
+- Return reactive state via `ref`/`computed` and expose only necessary values
+- Handle network errors gracefully and provide fallbacks
+
+# Common Issues and Solutions
+- **`undefined` runtime config**: check that required environment variables like `STRAPI_URL` are set
+- **State not updating**: ensure reactive values are created with `ref` or `reactive`
+
+# Related Documentation
+- [../AGENTS.md](../AGENTS.md)
+- [../components/AGENTS.md](../components/AGENTS.md)
+- [../pages/AGENTS.md](../pages/AGENTS.md)
+- [../data/AGENTS.md](../data/AGENTS.md)
+

--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -1,0 +1,28 @@
+# Overview and Purpose
+Static TypeScript modules that provide mock data or constants used throughout the app. Currently used to supply blog posts when the Strapi CMS is unavailable.
+
+# Technical Specifications
+- Files export typed data structures for direct import
+- `blog-posts.ts` contains an array of article records mirroring the Strapi schema
+- Imports use the `~/data` alias for clarity
+
+# Usage Examples
+```ts
+import blogPosts from '~/data/blog-posts'
+
+console.log(blogPosts.length)
+```
+
+# Best Practices
+- Keep mock data minimal and representative of real responses
+- Update interfaces when the backend schema changes
+- Separate large datasets into multiple files if needed
+
+# Common Issues and Solutions
+- **Stale mock content**: refresh the data to match current API responses
+- **Incorrect import path**: prefix with `~/data` to resolve files properly
+
+# Related Documentation
+- [../AGENTS.md](../AGENTS.md)
+- [../composables/AGENTS.md](../composables/AGENTS.md)
+

--- a/layouts/AGENTS.md
+++ b/layouts/AGENTS.md
@@ -32,4 +32,5 @@ Layout templates that wrap page content and provide persistent UI elements like 
 - [../AGENTS.md](../AGENTS.md)
 - [../components/AGENTS.md](../components/AGENTS.md)
 - [../pages/AGENTS.md](../pages/AGENTS.md)
+- [../composables/AGENTS.md](../composables/AGENTS.md)
 

--- a/pages/AGENTS.md
+++ b/pages/AGENTS.md
@@ -1,18 +1,20 @@
 # Overview and Purpose
-Route components that render public pages for the site.
+Route components that render public pages for the site, including dynamic blog routes.
 
 # Technical Specifications
 - Files in this directory are automatically registered as routes by Nuxt 4
 - Pages compose UI from components and use `<script setup lang="ts">`
+- Blog pages under `/blog` fetch articles from Strapi via composables
 
 # Usage Examples
 ```vue
 <script setup lang="ts">
-// page-specific logic
+const { all, fetchBlogPosts } = useBlog()
+await fetchBlogPosts()
 </script>
 
 <template>
-  <HeroSection />
+  <BlogCard v-for="post in all" :key="post.id" :post="post" />
 </template>
 ```
 
@@ -20,6 +22,7 @@ Route components that render public pages for the site.
 - Keep templates declarative and move complex logic into reusable components or composables
 - Use descriptive Spanish file names that map directly to route paths
 - Add SEO metadata within the `<head>` helper when required
+- Leverage composables like `useBlog` for data fetching
 
 # Common Issues and Solutions
 - **Unexpected route path**: ensure the file name matches the desired URL segment
@@ -29,4 +32,6 @@ Route components that render public pages for the site.
 - [../AGENTS.md](../AGENTS.md)
 - [../components/AGENTS.md](../components/AGENTS.md)
 - [../layouts/AGENTS.md](../layouts/AGENTS.md)
+- [../composables/AGENTS.md](../composables/AGENTS.md)
+- [../data/AGENTS.md](../data/AGENTS.md)
 

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -30,4 +30,5 @@ export default defineNuxtPlugin((nuxtApp) => {
 - [../AGENTS.md](../AGENTS.md)
 - [../components/AGENTS.md](../components/AGENTS.md)
 - [../layouts/AGENTS.md](../layouts/AGENTS.md)
+- [../composables/AGENTS.md](../composables/AGENTS.md)
 

--- a/public/AGENTS.md
+++ b/public/AGENTS.md
@@ -9,6 +9,7 @@ Static files served directly at the site root.
 # Usage Examples
 - `public/robots.txt` is available at `/robots.txt`
 - `public/img/logo.jpg` can be referenced as `<img src="/img/logo.jpg" />`
+- `public/sitemap.xml` serves the generated sitemap at `/sitemap.xml`
 
 # Best Practices
 - Store only assets that require no bundling or transformation


### PR DESCRIPTION
## Summary
- document composable utilities and data mocks with new AGENTS files
- note blog markdown dependency and cross-link all AGENTS guides
- expand pages and components docs for upcoming blog integration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not load @nuxtjs/strapi. Is it installed?)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1e108f5c832f8d34a0c0d4132892