### PR TITLE
Fix sitemap configuration for Nuxt 4

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,12 @@ export default defineNuxtConfig({
   compatibilityDate: "2025-07-15",
   devtools: { enabled: true },
   modules: ['@nuxtjs/sitemap', '@nuxtjs/strapi'],
+  site: {
+    url: 'https://soygioco.art',
+    name: 'Soy Gioco Arte',
+    description: 'Talleres de acrílico y acuarela en Costa Rica',
+    defaultLocale: 'es'
+  },
   runtimeConfig: {
     public: {
       strapiURL: process.env.STRAPI_URL || '',
@@ -16,7 +22,6 @@ export default defineNuxtConfig({
     prefix: '/api'
   },
   sitemap: {
-    hostname: 'https://soygioco.art',
     gzip: true,
     routes: async () => {
       const staticRoutes = ['/', '/biografia', '/servicios', '/talleres', '/comunidad', '/faq']


### PR DESCRIPTION
## Summary
- configure site metadata via `site.url` for `@nuxtjs/sitemap`
- remove deprecated `hostname` option from sitemap module

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68ae208ab9f8832f857d19f13795b0fd