### PR TITLE
fix: remove deprecated gzip option from sitemap config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,7 +22,6 @@ export default defineNuxtConfig({
     prefix: '/api'
   },
   sitemap: {
-    gzip: true,
     routes: async () => {
       const staticRoutes = ['/', '/biografia', '/servicios', '/talleres', '/comunidad', '/faq']
       // TODO: add dynamic blog routes here when blog functionality is implemented


### PR DESCRIPTION
## Summary
- remove deprecated `gzip` option from @nuxtjs/sitemap config

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ae22e54e68832f8ca9849893f461a1