### PR TITLE
Optimize bundle with manual chunking and lazy-loaded blog markdown

### DIFF
--- a/components/blog/BlogContent.vue
+++ b/components/blog/BlogContent.vue
@@ -6,10 +6,13 @@
 </template>
 
 <script setup lang="ts">
-import { marked } from 'marked'
 import type { BlogPost } from '~/composables/useBlog'
 
 const props = defineProps<{ post: BlogPost }>()
+const html = ref('')
 
-const html = computed(() => marked.parse(props.post.content))
+onMounted(async () => {
+  const { marked } = await import('marked')
+  html.value = marked.parse(props.post.content)
+})
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -56,5 +56,28 @@ export default defineNuxtConfig({
       noExternal: ["vuetify"],
     },
     plugins: [vuetify()],
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              if (id.includes('vuetify')) {
+                return 'vuetify'
+              }
+              if (id.includes('@mdi')) {
+                return 'mdi'
+              }
+              if (id.includes('@nuxtjs/strapi') || id.includes('strapi')) {
+                return 'strapi'
+              }
+              if (id.includes('marked')) {
+                return 'marked'
+              }
+              return 'vendor'
+            }
+          }
+        }
+      }
+    }
   }
 });

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -12,11 +12,12 @@
 
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router'
-import BlogContent from '~/components/blog/BlogContent.vue'
-import BlogNavigation from '~/components/blog/BlogNavigation.vue'
+import { defineAsyncComponent } from 'vue'
 import { useBlog } from '~/composables/useBlog'
 import { useSeo } from '~/composables/useSeo'
 
+const BlogContent = defineAsyncComponent(() => import('~/components/blog/BlogContent.vue'))
+const BlogNavigation = defineAsyncComponent(() => import('~/components/blog/BlogNavigation.vue'))
 const route = useRoute()
 const router = useRouter()
 const { fetchBlogPost, loading } = useBlog()


### PR DESCRIPTION
## Summary
- Split heavy dependencies like Vuetify, MDI icons, Strapi and marked into dedicated vendor chunks via Vite manual chunk config.
- Lazy-load blog markdown by dynamically importing marked and loading blog components asynchronously.

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ae224cfbec832f9071b2618fdd0527