### PR TITLE
fix: update sitemap config to use urls property

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,7 +22,7 @@ export default defineNuxtConfig({
     prefix: '/api'
   },
   sitemap: {
-    routes: async () => {
+    urls: async () => {
       const staticRoutes = ['/', '/biografia', '/servicios', '/talleres', '/comunidad', '/faq']
       // TODO: add dynamic blog routes here when blog functionality is implemented
       return staticRoutes


### PR DESCRIPTION
## Summary
- use `urls` instead of deprecated `routes` in sitemap config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68ae2f658198832fa404b7f34b11c44c