### PR TITLE
feat: enhance blog listing page

### DIFF
--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -26,7 +26,7 @@
     </v-card-item>
     <v-spacer />
     <v-card-actions class="mt-auto">
-      <div class="text-caption">Por Gioco</div>
+      <div class="text-caption">Por {{ author }}</div>
       <v-spacer />
       <v-btn color="primary" variant="flat">Leer Artículo</v-btn>
     </v-card-actions>
@@ -38,6 +38,7 @@ import type { BlogPost } from '~/composables/useBlog'
 
 const runtimeConfig = useRuntimeConfig()
 const url = ref('')
+const author = ref('')
 
 const props = defineProps<{ post: BlogPost }>()
 
@@ -56,5 +57,6 @@ const truncatedDescription = computed(() => {
 
 onMounted(() => {
   url.value = runtimeConfig.public.strapiURL + props.post.featured_image.url
+  author.value = props.post.author
 })
 </script>

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -1,19 +1,60 @@
 <template>
-  <v-card :to="`/blog/${post.slug}`" class="mx-auto" max-width="344">
-    <v-img :src="url" :alt="post.featured_image.alt" height="200" cover />
-    <v-card-title>{{ post.title }}</v-card-title>
-    <v-card-subtitle>{{ post.description }}</v-card-subtitle>
+  <v-card
+    :to="`/blog/${post.slug}`"
+    class="d-flex flex-column h-100"
+    :elevation="2"
+    rounded="lg"
+  >
+    <v-img
+      :src="url"
+      :alt="post.featured_image.alt"
+      height="200"
+      cover
+      class="rounded-t-lg"
+    />
+    <v-card-item class="pt-4">
+      <v-chip color="primary" size="small" class="mb-2" label>
+        {{ post.category }}
+      </v-chip>
+      <v-card-title class="text-h6">{{ post.title }}</v-card-title>
+      <v-card-subtitle class="text-body-2 mb-2">
+        {{ formattedDate }} · {{ post.reading_time }} min
+      </v-card-subtitle>
+      <v-card-text class="pt-0 text-body-2">
+        {{ truncatedDescription }}
+      </v-card-text>
+    </v-card-item>
+    <v-spacer />
+    <v-card-actions class="mt-auto">
+      <div class="text-caption">Por Gioco</div>
+      <v-spacer />
+      <v-btn color="primary" variant="flat">Leer Artículo</v-btn>
+    </v-card-actions>
   </v-card>
 </template>
 
 <script setup lang="ts">
 import type { BlogPost } from '~/composables/useBlog'
-const runtimeConfig = useRuntimeConfig();
+
+const runtimeConfig = useRuntimeConfig()
 const url = ref('')
 
 const props = defineProps<{ post: BlogPost }>()
 
-onMounted(async ()=> {
+const formattedDate = computed(() =>
+  new Date(props.post.created_at).toLocaleDateString('es-ES', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  })
+)
+
+const truncatedDescription = computed(() => {
+  const desc = props.post.description || ''
+  return desc.length > 200 ? desc.slice(0, 200) + '…' : desc
+})
+
+onMounted(() => {
   url.value = runtimeConfig.public.strapiURL + props.post.featured_image.url
 })
 </script>

--- a/components/blog/BlogSearch.vue
+++ b/components/blog/BlogSearch.vue
@@ -1,25 +1,68 @@
 <template>
-  <v-row class="mb-4" align="center">
-    <v-col cols="12" md="6">
-      <v-text-field v-model="searchModel" label="Buscar" prepend-inner-icon="mdi-magnify" clearable />
-    </v-col>
-    <v-col cols="12" md="4">
-      <v-select v-model="categoryModel" :items="categories" label="Categoría" clearable />
-    </v-col>
-  </v-row>
+  <div class="mb-4">
+    <v-text-field
+      v-model="searchModel"
+      placeholder="Buscar por título, técnica, tema o palabra clave..."
+      prepend-inner-icon="mdi-magnify"
+      :append-inner-icon="searchModel ? 'mdi-close' : undefined"
+      clearable
+      hide-details
+      @click:append-inner="searchModel = ''"
+    />
+    <v-chip-group
+      v-model="categoriesModel"
+      multiple
+      class="d-flex flex-wrap mt-2"
+    >
+      <v-chip
+        v-for="cat in categories"
+        :key="cat.name"
+        :value="cat.name"
+        variant="outlined"
+        filter
+        class="ma-1"
+        :color="categoriesModel.includes(cat.name) ? 'primary' : undefined"
+      >
+        {{ cat.name }}
+        <v-badge :content="cat.count" inline class="ml-1" color="primary" />
+      </v-chip>
+    </v-chip-group>
+    <v-btn
+      v-if="categoriesModel.length"
+      class="mt-2"
+      size="small"
+      variant="text"
+      @click="categoriesModel = []"
+    >
+      Limpiar filtros
+    </v-btn>
+  </div>
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{ search: string; category: string; categories: string[] }>()
-const emit = defineEmits<{ (e: 'update:search', value: string): void; (e: 'update:category', value: string): void }>()
+interface CategoryItem {
+  name: string
+  count: number
+}
+
+const props = defineProps<{
+  search: string
+  selectedCategories: string[]
+  categories: CategoryItem[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:search', value: string): void
+  (e: 'update:selectedCategories', value: string[]): void
+}>()
 
 const searchModel = computed({
   get: () => props.search,
   set: v => emit('update:search', v)
 })
 
-const categoryModel = computed({
-  get: () => props.category,
-  set: v => emit('update:category', v)
+const categoriesModel = computed({
+  get: () => props.selectedCategories,
+  set: v => emit('update:selectedCategories', v)
 })
 </script>

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -3,15 +3,23 @@
     <BlogHero />
     <BlogSearch
       v-model:search="search"
-      v-model:category="category"
+      v-model:selectedCategories="selectedCategories"
       :categories="categories"
     />
+    <v-alert v-if="!loading" variant="tonal" class="mb-4">
+      {{ filtered.length }} resultados encontrados
+    </v-alert>
     <BlogSkeleton v-if="loading" />
-    <v-row v-else>
-      <v-col v-for="post in paginated" :key="post.id" cols="12" md="4">
-        <BlogCard :post="post" />
-      </v-col>
-    </v-row>
+    <div v-else>
+      <v-alert v-if="filtered.length === 0" type="warning" class="mb-4">
+        No se encontraron resultados. Intenta ajustar tu búsqueda o filtros.
+      </v-alert>
+      <v-row v-else>
+        <v-col v-for="post in paginated" :key="post.id" cols="12" sm="6" md="4" lg="3">
+          <BlogCard :post="post" />
+        </v-col>
+      </v-row>
+    </div>
     <div ref="infiniteRef"></div>
   </v-container>
 </template>
@@ -29,7 +37,7 @@ const { all, loading, fetchBlogPosts } = useBlog()
 
 onMounted(fetchBlogPosts)
 
-const { search, category, categories, paginated, hasMore, loadMorePosts } = useBlogSearch(all)
+const { search, selectedCategories, categories, filtered, paginated, hasMore, loadMorePosts } = useBlogSearch(all)
 
 const { target: infiniteRef } = useInfiniteScroll(() => {
   if (hasMore.value && !loading.value) {


### PR DESCRIPTION
## Summary
- revamp search bar with placeholder, clear icon, and chip-based category filters
- redesign blog cards with category badges, metadata, and call-to-action
- show result counts and responsive grid with empty-state feedback

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68b09259adac832f8d90971e5322db6d