### PR TITLE
fix: ensure blog images hydrate correctly

### DIFF
--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -37,10 +37,16 @@
 import type { BlogPost } from '~/composables/useBlog'
 
 const runtimeConfig = useRuntimeConfig()
-const url = ref('')
-const author = ref('')
 
 const props = defineProps<{ post: BlogPost }>()
+
+const url = computed(() =>
+  props.post?.featured_image?.url
+    ? runtimeConfig.public.strapiURL + props.post.featured_image.url
+    : '/img/logo.jpg'
+)
+
+const author = computed(() => props.post.author)
 
 const formattedDate = computed(() =>
   new Date(props.post.created_at).toLocaleDateString('es-ES', {
@@ -53,10 +59,5 @@ const formattedDate = computed(() =>
 const truncatedDescription = computed(() => {
   const desc = props.post.description || ''
   return desc.length > 200 ? desc.slice(0, 200) + '…' : desc
-})
-
-onMounted(() => {
-  url.value = runtimeConfig.public.strapiURL + props.post.featured_image.url
-  author.value = props.post.author
 })
 </script>

--- a/components/blog/BlogContent.vue
+++ b/components/blog/BlogContent.vue
@@ -14,17 +14,19 @@
 
 <script setup lang="ts">
 import type { BlogPost } from '~/composables/useBlog'
+import { marked } from 'marked'
+
 const runtimeConfig = useRuntimeConfig();
 
 const props = defineProps<{ post: BlogPost }>()
-const html = ref('')
-const url = ref('')
 
-onMounted(async () => {
-  const { marked } = await import('marked')
-  html.value = marked.parse(props.post.content)
-  url.value = runtimeConfig.public.strapiURL + props.post?.featured_image?.url
-})
+const url = computed(() =>
+  props.post?.featured_image?.url
+    ? runtimeConfig.public.strapiURL + props.post.featured_image.url
+    : '/img/logo.jpg'
+)
+
+const html = computed(() => marked.parse(props.post.content))
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- compute blog image URLs during SSR and provide fallback
- render blog content HTML server-side for consistent hydration

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b2a72b3dd0832faff5c4aa3ab95820