### PR TITLE
chore: enable Netlify preset

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,9 @@ export default defineNuxtConfig({
   compatibilityDate: "2025-07-15",
   devtools: { enabled: true },
   modules: ['@nuxtjs/sitemap', '@nuxtjs/strapi'],
+  nitro: {
+    preset: 'netlify'
+  },
   site: {
     url: 'https://soygiocoart.netlify.app/',
     name: 'Soy Gioco Arte',


### PR DESCRIPTION
## Summary
- configure Nitro with Netlify preset to generate Netlify-compatible build output

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b2a8a6025c832f93e08b31feb2c2bd