### PR TITLE
fix netlify node version for crypto.hash error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,4 @@ publish = ".output/public"
 functions = ".output/server/functions"
 
 [build.environment]
-NODE_VERSION = "18"
+NODE_VERSION = "20"


### PR DESCRIPTION
## Summary
- use Node.js 20 in Netlify build to support `crypto.hash`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b2ac389fb8832f9abc4c3cca005227