### PR TITLE
feat: add v-img-style wrappers for NuxtImg

### DIFF
--- a/assets/css/nuxt-img-styles.css
+++ b/assets/css/nuxt-img-styles.css
@@ -1,0 +1,82 @@
+/* NuxtImg V-img Style Replacement */
+
+/* Base container styles */
+.nuxt-img-container {
+  position: relative;
+  overflow: hidden;
+  display: block;
+  width: 100%;
+}
+
+/* Object-fit variants */
+.nuxt-img-cover {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.nuxt-img-contain {
+  object-fit: contain;
+  width: 100%;
+  height: 100%;
+}
+
+.nuxt-img-fill {
+  object-fit: fill;
+  width: 100%;
+  height: 100%;
+}
+
+/* Gallery specific styles */
+.gallery-image-container {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
+}
+
+.gallery-image-container:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+}
+
+/* Loading states */
+.nuxt-img-placeholder {
+  background: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: #666;
+}
+
+.nuxt-img-loading {
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+/* Responsive aspect ratios */
+.aspect-square { aspect-ratio: 1/1; }
+.aspect-4-3 { aspect-ratio: 4/3; }
+.aspect-16-9 { aspect-ratio: 16/9; }
+.aspect-3-2 { aspect-ratio: 3/2; }
+
+/* Grid layout helpers */
+.gallery-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+
+@media (max-width: 768px) {
+  .gallery-grid {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 0.5rem;
+  }
+}

--- a/components/BannerComunidad.vue
+++ b/components/BannerComunidad.vue
@@ -3,17 +3,22 @@
     <v-row align="center" justify="center">
       <!-- Imagen - Responsive -->
       <v-col cols="12" md="6" class="text-center">
-        <NuxtImg
-          src="/img/logo.jpg"
-          alt="Comunidad Soy Gioco"
-          :width="$vuetify.display.mobile ? 200 : 400"
-          :height="$vuetify.display.mobile ? 200 : 300"
-          :style="{ objectFit: 'contain' }"
-          class="mx-auto rounded-lg"
-          loading="eager"
-          fetchpriority="high"
-          decoding="sync"
-        />
+        <div
+          class="nuxt-img-container mx-auto rounded-lg"
+          :style="{ maxWidth: $vuetify.display.mobile ? '200px' : '400px' }"
+        >
+          <NuxtImg
+            src="/img/logo.jpg"
+            alt="Comunidad Soy Gioco"
+            :width="$vuetify.display.mobile ? 200 : 400"
+            :height="$vuetify.display.mobile ? 200 : 300"
+            class="nuxt-img-contain"
+            :style="{ aspectRatio: $vuetify.display.mobile ? '1/1' : '4/3' }"
+            loading="eager"
+            fetchpriority="high"
+            decoding="sync"
+          />
+        </div>
       </v-col>
       
       <!-- Contenido de texto -->
@@ -52,8 +57,4 @@
   }
 }
 
-/* Asegurar que la imagen no se desborde */
-.v-img {
-  border-radius: 8px;
-}
 </style>

--- a/components/BioCompleta.vue
+++ b/components/BioCompleta.vue
@@ -8,21 +8,19 @@
         lg="3"
         class="text-center"
       >
-        <NuxtImg
-          src="/img/gioconda-cerdas.png"
-          alt="Gioconda Cerdas Agüero"
-          class="rounded-circle elevation-3"
-          style="
-            max-width: 280px;
-            width: 100%;
-            height: auto;
-            object-fit: cover;
-          "
-          loading="eager"
-          fetchpriority="high"
-          decoding="sync"
-          sizes="sm:100vw md:50vw lg:400px"
-        />
+        <div class="nuxt-img-container mx-auto rounded-circle elevation-3" style="max-width: 280px">
+          <NuxtImg
+            src="/img/gioconda-cerdas.png"
+            alt="Gioconda Cerdas Agüero"
+            width="280"
+            height="280"
+            class="nuxt-img-cover aspect-square"
+            loading="eager"
+            fetchpriority="high"
+            decoding="sync"
+            sizes="sm:100vw md:50vw lg:400px"
+          />
+        </div>
       </v-col>
       
       <!-- Content Column -->

--- a/components/BioResumen.vue
+++ b/components/BioResumen.vue
@@ -3,17 +3,18 @@
     <v-row align="center" justify="center" class="text-center text-sm-left">
       <v-col cols="12" sm="4" md="3">
         <!-- Profile image - suggested 200x200 -->
-        <NuxtImg
-          src="/img/gioconda-cerdas.png"
-          alt="Gioconda Cerdas sonriendo"
-          width="200"
-          height="200"
-          style="object-fit:cover"
-          class="rounded-circle mx-auto"
-          loading="eager"
-          fetchpriority="high"
-          decoding="sync"
-        />
+        <div class="nuxt-img-container mx-auto" style="max-width: 200px">
+          <NuxtImg
+            src="/img/gioconda-cerdas.png"
+            alt="Gioconda Cerdas sonriendo"
+            width="200"
+            height="200"
+            class="nuxt-img-cover aspect-square rounded-circle"
+            loading="eager"
+            fetchpriority="high"
+            decoding="sync"
+          />
+        </div>
       </v-col>
       <v-col cols="12" sm="8" md="7">
         <h2 class="text-h5 font-weight-medium mb-4">Sobre mí</h2>

--- a/components/GaleriaPreview.vue
+++ b/components/GaleriaPreview.vue
@@ -1,30 +1,22 @@
 <template>
   <v-container class="py-12 text-center">
     <h2 class="text-h5 font-weight-medium mb-8">Galería de Estudiantes</h2>
-    <v-row class="mb-4">
-      <v-col
-        v-for="obra in obras"
-        :key="obra.src"
-        cols="12"
-        xs="12"
-        sm="6"
-        md="4"
-        lg="3"
-      >
-        <NuxtImg
-          :src="obra.src"
-          :alt="obra.caption"
-          height="400"
-          style="object-fit:cover"
-          class="mb-2"
-          loading="eager"
-          fetchpriority="high"
-          decoding="sync"
-          sizes="sm:100vw md:50vw lg:400px"
-        />
-        <p class="text-caption">{{ obra.caption }}</p>
-      </v-col>
-    </v-row>
+    <div class="gallery-grid mb-4">
+      <div v-for="obra in obras" :key="obra.src">
+        <div class="gallery-image-container nuxt-img-container elevation-2 rounded-lg">
+          <NuxtImg
+            :src="obra.src"
+            :alt="obra.caption"
+            width="300"
+            height="225"
+            class="nuxt-img-cover aspect-4-3"
+            loading="lazy"
+            sizes="sm:100vw md:50vw lg:33vw xl:25vw"
+          />
+        </div>
+        <p class="text-caption mt-2">{{ obra.caption }}</p>
+      </div>
+    </div>
     <v-btn
       color="primary"
       href="https://www.instagram.com/soygioco.cr/"

--- a/components/HeroSection.vue
+++ b/components/HeroSection.vue
@@ -21,13 +21,34 @@
       </v-col>
       <v-col cols="12" md="5" class="text-center">
         <!-- Main hero image - suggested size 800x600 -->
-        <NuxtImg src="/img/foto-principal.jpg" alt="Ambiente relajado de una clase de pintura" height="300"
-          style="object-fit:cover;object-position:top center" class="rounded-lg mb-4 d-none d-md-block"
-          loading="eager" fetchpriority="high" decoding="sync" sizes="sm:100vw md:50vw lg:400px" />
+        <div class="nuxt-img-container rounded-lg mb-4 d-none d-md-block">
+          <NuxtImg
+            src="/img/foto-principal.jpg"
+            alt="Ambiente relajado de una clase de pintura"
+            width="800"
+            height="600"
+            class="nuxt-img-cover aspect-4-3"
+            :style="{ objectPosition: 'top center' }"
+            loading="eager"
+            fetchpriority="high"
+            decoding="sync"
+            sizes="sm:100vw md:50vw lg:400px"
+          />
+        </div>
         <!-- Secondary image - suggested size 400x300 -->
-        <NuxtImg src="/img/taller-ejemplo.jpeg" alt="Estudiantes pintando en su primer taller" height="200"
-          style="object-fit:cover" class="rounded-lg" loading="eager" fetchpriority="high" decoding="sync"
-          sizes="sm:100vw md:50vw lg:400px" />
+        <div class="nuxt-img-container rounded-lg">
+          <NuxtImg
+            src="/img/taller-ejemplo.jpeg"
+            alt="Estudiantes pintando en su primer taller"
+            width="400"
+            height="300"
+            class="nuxt-img-cover aspect-4-3"
+            loading="eager"
+            fetchpriority="high"
+            decoding="sync"
+            sizes="sm:100vw md:50vw lg:400px"
+          />
+        </div>
       </v-col>
     </v-row>
   </v-container>

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -3,7 +3,18 @@
     <v-app-bar-nav-icon class="d-sm-none" @click="drawer = !drawer" />
     <v-toolbar-title>
       <NuxtLink to="/">
-        <NuxtImg src="/img/logo.jpg" alt="SoyGioco Logo" width="40" height="40" loading="eager" fetchpriority="high" decoding="sync" />
+        <div class="nuxt-img-container" style="width: 40px; height: 40px">
+          <NuxtImg
+            src="/img/logo.jpg"
+            alt="SoyGioco Logo"
+            width="40"
+            height="40"
+            class="nuxt-img-contain"
+            loading="eager"
+            fetchpriority="high"
+            decoding="sync"
+          />
+        </div>
       </NuxtLink>
     </v-toolbar-title>
     <v-spacer />

--- a/components/TallerCard.vue
+++ b/components/TallerCard.vue
@@ -1,16 +1,19 @@
 <template>
   <v-card class="mx-auto" max-width="344">
     <!-- Taller image - suggested 400x300 -->
-    <NuxtImg
-      :src="image"
-      :alt="`Proceso creativo del taller ${title}`"
-      height="200"
-      style="object-fit:cover"
-      loading="eager"
-      fetchpriority="high"
-      decoding="sync"
-      sizes="sm:100vw md:50vw lg:400px"
-    />
+    <div class="nuxt-img-container">
+      <NuxtImg
+        :src="image"
+        :alt="`Proceso creativo del taller ${title}`"
+        width="400"
+        height="300"
+        class="nuxt-img-cover aspect-4-3"
+        loading="eager"
+        fetchpriority="high"
+        decoding="sync"
+        sizes="sm:100vw md:50vw lg:400px"
+      />
+    </div>
     <v-card-item>
       <v-card-title>{{ title }} - {{ technique }}</v-card-title>
       <v-card-subtitle class="py-1">

--- a/components/TematicaCard.vue
+++ b/components/TematicaCard.vue
@@ -6,16 +6,19 @@
       :elevation="isHovering ? 8 : 2"
       :style="{ transform: isHovering ? 'scale(1.02)' : 'scale(1)' }"
     >
-      <NuxtImg
-        :src="image"
-        :alt="alt"
-        height="180"
-        style="object-fit:cover"
-        loading="eager"
-        fetchpriority="high"
-        decoding="sync"
-        sizes="sm:100vw md:50vw lg:400px"
-      />
+      <div class="nuxt-img-container">
+        <NuxtImg
+          :src="image"
+          :alt="alt"
+          width="240"
+          height="180"
+          class="nuxt-img-cover aspect-4-3"
+          loading="eager"
+          fetchpriority="high"
+          decoding="sync"
+          sizes="sm:100vw md:50vw lg:400px"
+        />
+      </div>
       <v-card-item>
         <v-card-title class="text-h6">{{ title }}</v-card-title>
         <v-card-subtitle class="text-body-2">

--- a/components/TematicaCard.vue
+++ b/components/TematicaCard.vue
@@ -2,6 +2,7 @@
   <v-hover v-slot="{ isHovering, props: hoverProps }">
     <v-card
       v-bind="hoverProps"
+      :id="props.id"
       class="transition-smooth d-flex flex-column h-100"
       :elevation="isHovering ? 8 : 2"
       :style="{ transform: isHovering ? 'scale(1.02)' : 'scale(1)' }"
@@ -54,6 +55,8 @@
 import { computed } from 'vue'
 
 interface Tematica {
+  id?: string
+  featured?: boolean
   title: string
   description: string
   image: string
@@ -61,6 +64,12 @@ interface Tematica {
   difficulty: string
 }
 
-const props = defineProps<Tematica>()
+const props = withDefaults(
+  defineProps<Tematica>(),
+  {
+    featured: false,
+  }
+)
+
 const alt = computed(() => `Arte de la temática ${props.title}`)
 </script>

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -5,17 +5,19 @@
     :elevation="2"
     rounded="lg"
   >
-    <NuxtImg
-      :src="url"
-      :alt="post.featured_image.alt || 'Imagen'"
-      height="200"
-      style="object-fit:cover"
-      class="rounded-t-lg"
-      loading="eager"
-      fetchpriority="high"
-      decoding="sync"
-      sizes="sm:100vw md:50vw lg:400px"
-    />
+    <div class="nuxt-img-container rounded-t-lg">
+      <NuxtImg
+        :src="url"
+        :alt="post.featured_image.alt || 'Imagen'"
+        width="300"
+        height="225"
+        class="nuxt-img-cover aspect-4-3"
+        loading="eager"
+        fetchpriority="high"
+        decoding="sync"
+        sizes="sm:100vw md:50vw lg:400px"
+      />
+    </div>
     <v-card-item class="pt-4">
       <v-chip color="primary" size="small" class="mb-2" label>
         {{ post.category }}

--- a/components/blog/BlogContent.vue
+++ b/components/blog/BlogContent.vue
@@ -1,16 +1,18 @@
 <template>
   <div>
-    <NuxtImg
-      :src="url"
-      :alt="post.featured_image.alt || 'Imagen'"
-      height="400"
-      class="mb-4"
-      style="object-fit:cover"
-      loading="eager"
-      fetchpriority="high"
-      decoding="sync"
-      sizes="sm:100vw md:50vw lg:400px"
-    />
+    <div class="nuxt-img-container mb-4">
+      <NuxtImg
+        :src="url"
+        :alt="post.featured_image.alt || 'Imagen'"
+        width="600"
+        height="400"
+        class="nuxt-img-cover aspect-3-2"
+        loading="eager"
+        fetchpriority="high"
+        decoding="sync"
+        sizes="sm:100vw md:50vw lg:400px"
+      />
+    </div>
     <div class="article-content" v-html="html" />
   </div>
 </template>

--- a/components/blog/BlogRelated.vue
+++ b/components/blog/BlogRelated.vue
@@ -4,8 +4,19 @@
     <v-row>
       <v-col v-for="p in posts" :key="p.slug" cols="12" md="4">
         <v-card :to="`/blog/${p.slug}`" elevation="1">
-          <NuxtImg :src="p.featured_image" :alt="p.title" height="120" style="object-fit:cover"
-            loading="eager" fetchpriority="high" decoding="sync" sizes="sm:100vw md:50vw lg:400px" />
+          <div class="nuxt-img-container">
+            <NuxtImg
+              :src="p.featured_image"
+              :alt="p.title"
+              width="160"
+              height="120"
+              class="nuxt-img-cover aspect-4-3"
+              loading="eager"
+              fetchpriority="high"
+              decoding="sync"
+              sizes="sm:100vw md:50vw lg:400px"
+            />
+          </div>
           <v-card-title class="text-body-1">{{ p.title }}</v-card-title>
         </v-card>
       </v-col>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,7 +54,7 @@ export default defineNuxtConfig({
       link: [{ rel: "icon", type: "image/jpeg", href: "/img/logo.jpg" }],
     },
   },
-  css: ["vuetify/styles", "@mdi/font/css/materialdesignicons.min.css"],
+  css: ["vuetify/styles", "@mdi/font/css/materialdesignicons.min.css", "~/assets/css/nuxt-img-styles.css"],
   build: {
     transpile: ["vuetify"],
   },


### PR DESCRIPTION
## Summary
- add global nuxt-img stylesheet with container, object-fit, and gallery helpers
- wrap NuxtImg usage with new classes for consistent aspect ratios and grid layouts
- import stylesheet in Nuxt config for app-wide usage

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b4839da3f0832f8d63b78b6ac5455f